### PR TITLE
Update TabState.bt

### DIFF
--- a/TabState.bt
+++ b/TabState.bt
@@ -46,6 +46,7 @@ enum <ubyte> Encoding {
 
 enum <ubyte> CarriageType { 
     CRLF = 1,
+    Macintosh = 2,
     Unix = 3,
 };
 

--- a/TabState.bt
+++ b/TabState.bt
@@ -45,8 +45,8 @@ enum <ubyte> Encoding {
 };
 
 enum <ubyte> CarriageType { 
-    Unix = 1,
-    CRLF = 3,
+    CRLF = 1,
+    Unix = 3,
 };
 
 typedef struct {


### PR DESCRIPTION
Updated enum for carriage return type. These appeared to have been flipped. 0x01 is CRLF and 0x03 is Unix.

Windows CRLF - 0x01
![image](https://github.com/Nordgaren/tabstate-util/assets/112595633/8e5b655d-9096-4ddf-a3dd-e462162d4cfd)

Unix LF - 0x03
![image](https://github.com/Nordgaren/tabstate-util/assets/112595633/7591ef77-cb1d-49fb-b752-1be2f9ecdcee)

